### PR TITLE
(#11417) Add EL 6 resource to configure pe-ruby-devel

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,6 +1,5 @@
 --format
 s
---colour
---loadby
+--color
 mtime
 --backtrace

--- a/README.markdown
+++ b/README.markdown
@@ -10,10 +10,104 @@ Enterprise already installed with the master role, these commands will put the
 Puppet pe\_devel module in the correct place.
 
     % cd /etc/puppetlabs/puppet/modules
-    % puppet-module install puppetlabs-pe_devel
+    % sudo puppet-module install puppetlabs-pe_devel
     Installed "puppetlabs-pe_devel-0.0.1" into directory: pe_devel
     % cd pe_devel
-    % sudop puppet apply -e 'include pe_devel'
+    % sudo puppet apply -e 'include pe_devel'
+
+# Installation from Source
+
+If this module is not available from the Forge or you'd like to work on it from
+source, perhaps to add support for a platform the module does not currently
+support you can manually build the package.  For example:
+
+    % cd ~/src/modules/pe_devel
+    % rake build
+    (in /Users/jeff/src/modules/pe_devel)
+    ============================================================
+    Building /Users/jeff/src/modules/pe_devel for release
+    ------------------------------------------------------------
+    Done. Built: pkg/puppetlabs-pe_devel-0.0.1.tar.gz
+
+Once build, the package may be installed replacing the name with the path to
+the package tar.gz file.  For example:
+
+    % cd /etc/puppetlabs/puppet/modules
+    % sudo puppet-module install \
+           ~jeff/src/modules/pe_devel/pkg/puppetlabs-pe_devel-0.0.1.tar.gz
+    Installed "puppetlabs-pe_devel-0.0.1" into directory: pe_devel
+    % cd pe_devel
+    % sudo puppet apply -e 'include pe_devel'
+
+NOTE: When frequently installing from source, make sure to clean your module
+cache before installing a newly build module otherwise you may installed an
+older, cached version of the module with the same name and version string.
+
+# Puppet Enterprise Packages via YUM
+
+This module makes the assumption that Puppet Enterprise packages are available
+via YUM using the base URL of
+[http://links.puppetlabs.com/puppet-enterprise](http://links.puppetlabs.com/puppet-enterprise)
+At the time of writing this URL re-directs to a Puppet Labs internal system
+because the Puppet Enterprise YUM repository is not currently available to the
+public.
+
+If you have Puppet Enterprise, it's possible to make the packages available
+using createrepo on an enterprise linux system like this example illustrates:
+
+    % cd /var/www/html
+    % mkdir -p puppet-enterprise/yum/2.0.0/base/el6/i386
+    % rsync -avxHP /tmp/puppet-enterprise-2.0.0-all/packages/el-6-i386/ \
+        /var/www/html/puppet-enterprise/yum/2.0.0/base/el6/i386/
+    % cd /var/www/html/puppet-enterprise/yum/2.0.0/base/el6/i386/
+    % createrepo .
+
+And then configure the module to use your own URL like so:
+
+    % sudo -s
+    # export FACTER_puppetenterprise_baseurl="http://yum.acme.lan/puppet-enterprise"
+    # puppet apply -v -e 'include pe_devel'
+
+NOTE: The module is currently using 2.0.0 directly in the
+puppetenterprise.repo.erb template.  A good place to improve the module would
+be to add a PE version fact to stdlib and make the URL more dynamic based on
+the Puppet Enterprise version the module is running on.
+
+# Expected Behavior
+
+If everything is setup correctly you should see these resources managed:
+
+    root@pe-centos6:~# puppet apply -v -e 'include pe_devel'
+    info: Loading facts in facter_dot_d
+    info: Loading facts in facter_dot_d
+    info: Applying configuration version '1323993947'
+    notice: /Stage[main]/Pe_devel::Redhat/Package[epel-release]/ensure: created
+    notice: /Stage[main]/Pe_devel::Redhat/File[puppetenterprise.repo]/ensure: defined content as '{md5}d044e92b6d23cd42efdca8d4cecb08c4'
+    notice: /Stage[main]/Pe_devel::Redhat/Package[createrepo]/ensure: created
+    notice: /Stage[main]/Pe_devel::Redhat/Package[glibc-devel]/ensure: created
+    notice: /Stage[main]/Pe_devel::Redhat/Package[wget]/ensure: created
+    notice: /Stage[main]/Pe_devel::Redhat/Package[gcc]/ensure: created
+    notice: /Stage[main]/Pe_devel::Redhat/Package[pe-ruby-devel]/ensure: created
+    notice: Finished catalog run in 22.97 seconds
+
+If the `pe-ruby-devel` package has trouble it likely means the node being
+managed does not have access to the system hosting the Puppet Enterprise
+packages referenced by the puppetenterprise\_baseurl parameter.  If the
+repository containing the `pe-ruby-devel` package is not available to the node
+being managed you can expect an error like this:
+
+    info: Loading facts in facter_dot_d
+    info: Loading facts in facter_dot_d
+    info: Applying configuration version '1323994960'
+    err: /Stage[main]/Pe_devel::Redhat/Package[pe-ruby-devel]/ensure: change from absent to latest failed: Could not update: Execution of '/usr/bin/yum -d 0 -e 0 -y install pe-ruby-devel' returned 1: 
+
+    Error Downloading Packages:
+      pe-ruby-devel-1.8.7.302-4.pe.el6.i386: failure: pe-ruby-devel-1.8.7.302-4.pe.el6.i386.rpm from pe_base: [Errno 256] No more mirrors to try.
+
+     at /etc/puppetlabs/puppet/modules/pe_devel/manifests/init.pp:127
+    notice: /Stage[main]/Pe_devel/Anchor[pe_devel::end]: Dependency Package[pe-ruby-devel] has failures: true
+    warning: /Stage[main]/Pe_devel/Anchor[pe_devel::end]: Skipping because of failed dependencies
+    notice: Finished catalog run in 3.33 seconds
 
 # RSpec Testing
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,18 +1,19 @@
 require 'rake'
+require 'rake/clean'
+require 'rubygems'
+require 'rspec'
+require 'rspec/core/rake_task'
+
+CLEAN.include('pkg/*')
 
 task :default => [:spec]
 
-desc "Run all module spec tests (Requires rspec-puppet gem)"
-task :spec do
-  system("rspec --format d spec")
+RSpec::Core::RakeTask.new do |t|
+  t.pattern = 'spec/**/*_spec.rb'
+  t.fail_on_error = true
 end
 
 desc "Build package"
 task :build do
-  system("puppet-module build")
-end
-
-desc "Clean packages"
-task :clean do
-  system("rm -rf pkg/*")
+  sh "puppet-module build"
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,17 +1,147 @@
-# Class: pe_devel
+# = Class: pe_devel
 #
-# This module manages pe_devel
+# This module manages common developer resources on PE supported platforms.
+# Initially it will be designed for Enterprise Linux 6 variants, but additional
+# platforms should be easy to add to the module.
 #
-# Parameters:
+# = Parameters
 #
-# Actions:
+# [*epel_release_url*]
+#   This parameter, if not provided will default to
+#   http://mirror.cogentco.com/pub/linux/epel/6/i386/epel-release-6-5.noarch.rpm
+#   The same parameter may also be set at as a node parameter in the event the
+#   Puppet Console is being used to set parameters.
 #
-# Requires:
+# [*puppetenterprise_baseurl*]
+#   This parameter is a URL to the base directory of an HTTP server providing
+#   the Puppet Enteprise packages in a repository format suitable for the node
+#   being managed by this module.  If left unspecified this parameter will
+#   default to http://links.puppetlabs.com/puppet-enterprise/ which will redirect
+#   accordingly.  NOTE, you can easily create your own repository using
+#   createrepo inside of the packages/ subdirectory of the Puppet Enterprise
+#   distribution tarball on YUM based platforms.
 #
-# Sample Usage:
+# = Actions
 #
-# [Remember: No empty lines between comments and class definition]
-class pe_devel {
+# The module aims to manage these resources on the PE system being developed
+# on.
+#
+# * wget
+# * curl
+# * build-essential or equivalent
+# * gcc
+# * make
+# * pe-ruby-devel
+#
+# = Requires
+#
+# The stdlib module.
+#
+# = Sample Usage
+#
+# puppet apply -v -e 'include pe_devel'
+#
+class pe_devel (
+  $epel_release_url = 'UNSET',
+  $puppetenterprise_baseurl = 'UNSET'
+) {
 
+  # Look up the epel release URL in the top scope if we don't have it here.
+  $epel_release_url_real = $epel_release_url ? {
+    UNSET => $::epel_release_url ? {
+      undef   => "http://mirror.cogentco.com/pub/linux/epel/6/i386/epel-release-6-5.noarch.rpm",
+      default => $::epel_release_url,
+    },
+    default => $epel_release_url,
+  }
+  # Validate the URL is a HTTP URL
+  validate_re($epel_release_url_real, '^https?://')
 
+  # Look up the PE repository URL.
+  $puppetenterprise_baseurl_real = $puppetenterprise_baseurl ? {
+    UNSET => $::puppetenterprise_baseurl ? {
+      undef   => "http://links.puppetlabs.com/puppet-enterprise",
+      default => $::puppetenterprise_baseurl,
+    },
+    default => $puppetenterprise_baseurl,
+  }
+  validate_re($puppetenterprise_baseurl_real, '^https?://')
+
+  # The Anchor Pattern is to work around Puppet issue 8040
+  # More information at: http://links.puppetlabs.com/anchor_pattern
+  anchor { "pe_devel::begin": }
+  anchor { "pe_devel::end": }
+
+  case $::osfamily {
+    redhat: {
+      class { 'pe_devel::redhat':
+        require => Anchor['pe_devel::begin'],
+        before  => Anchor['pe_devel::end'],
+      }
+    }
+    default: {
+      $msg = "OS Family: [${osfamily}] is not implemented"
+      # Master side warning
+      warning $msg
+      # Agent side notification
+      notify { "$module_name unimplemented": message => $msg }
+    }
+  }
 }
+
+class pe_devel::redhat {
+  Package {
+    ensure  => latest,
+    require => [ Package['epel-release'], File['puppetenterprise.repo'] ],
+  }
+  File {
+    owner => 0,
+    group => 0,
+    mode  => '0644',
+  }
+
+  # Look up the lsbmajdistrelease fact.
+  if $::lsbmajdistrelease {
+    # We can't install this package until the lsbmajdistrelease fact becomes available.
+    package { 'pe-ruby-devel': }
+  } else {
+    notify { "lsbmajdistrelease unavailable":
+      message => "The lsbmajdistrelease fact is not avilable during this catalog compilation.  The catalog contains the Package[redhat-lsb] resource to make the lsbmajdistrelease fact available on the next run.  Please run Puppet again to manage the pe-ruby-devel package and fill in the puppetenterprise.repo template."
+    }
+  }
+
+  # This selector prevents an ERB exception trying to look up a potentially missing
+  # fact.  The fact may be missing if the redhat-lsb package is not installed.
+  $puppetenterprise_repo_content = $::lsbmajdistrelease ? {
+    undef   => "# Contents not yet available.  Please run Puppet again.\n",
+    default => template("${module_name}/puppetenterprise.repo.erb"),
+  }
+
+  # JJM: REVISIT, We'll need this to support different PE versions automatically
+  # which means we'll need a PE major version facter fact in stdlib.
+  # Setup a repository source for Puppet Enterprise
+  file { 'puppetenterprise.repo':
+    path    => '/etc/yum.repos.d/puppetenterprise.repo',
+    content => $puppetenterprise_repo_content,
+  }
+  # This package gives us the $lsbmajdistrelease fact on the second run if it
+  # is not already available.
+  package { 'redhat-lsb': }
+
+  # The EPEL package is special because other packages can't be installed
+  # without it being present first.  We assign undef to the require parameter
+  # to avoid the resource default causing a dependency cycle in the graph.
+  package { epel-release:
+    ensure   => present,
+    provider => rpm,
+    source   => $pe_devel::epel_release_url_real,
+    require  => undef,
+  }
+  package { curl: }
+  package { wget: }
+  package { gcc: }
+  package { make: }
+  package { 'glibc-devel': }
+  package { createrepo: }
+}
+# EOF

--- a/spec/classes/pe_devel_spec.rb
+++ b/spec/classes/pe_devel_spec.rb
@@ -3,5 +3,62 @@ require 'spec_helper'
 # Note, rspec-puppet determines the class name from the top level describe
 # string.
 describe 'pe_devel' do
+  # Default Facts
+  before(:all) do
+    @facter_facts = {
+      'osfamily'      => 'RedHat',
+      'puppetversion' => '2.7.6 (Puppet Enterprise 2.0.0)',
+    }
+  end
+  let(:facts) do
+    @facter_facts
+  end
+  # The most essential test of the catalog
   it { should contain_class 'pe_devel' }
+
+  describe 'on redhat el6 os families' do
+    # This is the expected content of templates when lsbmajdistrelease is unavailable
+    let(:missing_content) do
+      "# Contents not yet available.  Please run Puppet again.\n"
+    end
+    it { should contain_class   'pe_devel::redhat' }
+    it { should contain_package 'gcc' }
+    it { should contain_package 'wget' }
+    it { should contain_package 'curl' }
+    it { should contain_package 'glibc-devel' }
+    it { should contain_package 'redhat-lsb' }
+
+    describe 'with lsbmajdistrelease available' do
+      let(:facts) do
+        @facter_facts.merge({'lsbmajdistrelease' => '6'})
+      end
+      it { should_not contain_file('puppetenterprise.repo').with_content(missing_content) }
+      it { should contain_package 'pe-ruby-devel' }
+      it do
+        pending "REVISIT - https://github.com/rodjek/rspec-puppet/pull/17 "
+        should contain_file('puppetenterprise.repo').with_content(/baseurl=http/)
+        should contain_file('puppetenterprise.repo').with_content(/pe_base/)
+        should contain_file('puppetenterprise.repo').with_content(/pe_updates/)
+        should contain_file('puppetenterprise.repo').with_content(/pe_extras/)
+      end
+    end
+
+    describe 'without lsbmajdistrelease available' do
+      let(:facts) do
+        my_facts = @facter_facts.dup
+        my_facts.delete 'lsbmajdistrelease'
+        my_facts
+      end
+      it { should contain_file('puppetenterprise.repo').with_content(missing_content) }
+      it { should_not contain_package 'pe-ruby-devel' }
+    end
+  end
+
+  describe 'on debian os families' do
+    let(:facts) do
+      @facter_facts.merge({ 'osfamily' => 'Debian' })
+    end
+    it { should contain_notify 'pe_devel unimplemented' }
+    it { should_not contain_class 'pe_devel::redhat' }
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,4 +4,6 @@ require 'rspec-puppet'
 
 RSpec.configure do |c|
   c.module_path = File.join(File.dirname(__FILE__), '../../')
+  # REVISIT This nees to be an empty file, rspec-puppet will always import it.
+  c.manifest = File.join(File.dirname(__FILE__), 'fixtures', 'manifests', 'site.pp')
 end

--- a/templates/puppetenterprise.repo.erb
+++ b/templates/puppetenterprise.repo.erb
@@ -1,0 +1,19 @@
+# Managed by Puppet <%= puppetversion %>
+# This file provides YUM access to Puppet Enterprise
+[pe_base]
+name=Puppet Enterprise Base
+baseurl=<%= scope.lookupvar('pe_devel::puppetenterprise_baseurl_real') %>/yum/2.0.0/base/el<%= lsbmajdistrelease %>/$basearch
+gpgcheck=0
+enabled=1
+
+[pe_updates]
+name=Puppet Enterprise Updates
+baseurl=<%= scope.lookupvar('pe_devel::puppetenterprise_baseurl_real') %>/yum/2.0.0/updates/el<%= lsbmajdistrelease %>/$basearch
+gpgcheck=0
+enabled=0
+
+[pe_extras]
+name=Puppet Enterprise Extras
+baseurl=<%= scope.lookupvar('pe_devel::puppetenterprise_baseurl_real') %>/yum/2.0.0/extras/el<%= lsbmajdistrelease %>/$basearch
+gpgcheck=0
+enabled=0


### PR DESCRIPTION
The whole point of this work and this module is for me to easily get
pe-ruby-devel on the PE system I'm developing on in order to build the
jenkins.rb gem for use with Puppet Enterprise.

To reach this goal, this patch does a number of things.  First, it
manages basic "build essentials" on my CentOS 6.1 system.  gcc, make,
glibc-devel, curl, wget, etc...

Next, the module manages the epel-release package so that we have
additional 3rd party packages available to us.

In the same vein, the module manages
/etc/yum.repos.d/puppetenterprise.repo  This is where Mike might flip
his lid, but I can't wait for him to write this module.  I've configured
the module to use a base URL of
http://links.puppetlabs.com/puppet-enterprise which for the moment uses
a 302 redirect to faro.puppetlabs.lan.  This works great with curl -L
and yum.  In the future we can simply update the link to point to
something public if we choose to do so.

For the time being this module will be BROKEN for anyone who is not
inside the Puppet Labs local area network.  =(

Once the repository is configured, the module uses a normal package
resource to manage pe-ruby-devel which is the whole point of this
effort.

It works:

```
notice: /Stage[main]/Pe_devel::Redhat/Package[pe-ruby-devel]/ensure:
created
```

Spec tests are included with this patch to validate the desired behavior
described in the ticket:

```
% rake spec
(in /Users/jeff/vms/puppet/modules/pe_devel)

pe_devel
  should create Class[pe_devel]
  on redhat el6 os families
    should create Class[pe_devel::redhat]
    should create Package[gcc]
    should create Package[wget]
    should create Package[curl]
    should create Package[glibc-devel]
    should create Package[pe-ruby-devel]
  on debian os families
    should create Notify[pe_devel unimplemented]
    should not create Class[pe_devel::redhat]

Finished in 0.64855 seconds
9 examples, 0 failures
```
